### PR TITLE
Fix: Disable font scaling

### DIFF
--- a/src/Initials.tsx
+++ b/src/Initials.tsx
@@ -21,7 +21,11 @@ const Initials = ({ size, name, color, colorize, borderRadius, style, textStyle 
 
   return (
     <View style={[styles.root, { borderRadius, backgroundColor }, style]}>
-      <Text style={[styles.text, { fontSize }, textStyle]} numberOfLines={1} allowFontScaling={false}>
+      <Text
+        style={[styles.text, { fontSize }, textStyle]}
+        numberOfLines={1}
+        allowFontScaling={false}
+      >
         {initials}
       </Text>
     </View>

--- a/src/Initials.tsx
+++ b/src/Initials.tsx
@@ -21,7 +21,7 @@ const Initials = ({ size, name, color, colorize, borderRadius, style, textStyle 
 
   return (
     <View style={[styles.root, { borderRadius, backgroundColor }, style]}>
-      <Text style={[styles.text, { fontSize }, textStyle]} numberOfLines={1}>
+      <Text style={[styles.text, { fontSize }, textStyle]} numberOfLines={1} allowFontScaling={false}>
         {initials}
       </Text>
     </View>


### PR DESCRIPTION
Initials avatar is scaled with the system settings on the phone, it should be disabled by default:

Now:
![IMG_0235](https://github.com/user-attachments/assets/7de5e887-8609-4314-8621-79a4006e7598)

After:
![IMG_0236](https://github.com/user-attachments/assets/53760d16-f0ef-4473-a1d8-cf931b880259)
